### PR TITLE
Suggested fix for dtype mismatches, when Akcv or wfdb is complex 128 …

### DIFF
--- a/yambopy/bse/realSpace_excitonwf.py
+++ b/yambopy/bse/realSpace_excitonwf.py
@@ -216,6 +216,7 @@ def ex_wf2Real_kernel(Akcv, Qpt, wfcdb, bse_bnds, fixed_postion,
     #
     ##
     # find the nearest fft grid point.
+    fixed_postion = fixed_postion.astype(np.float64)
     fx_pnt_int = np.floor(fixed_postion)
     fixed_postion -= fx_pnt_int
     fixed_postion = np.round(fixed_postion * fft_box) / fft_box
@@ -342,6 +343,10 @@ def ex_wf2Real_kernel(Akcv, Qpt, wfcdb, bse_bnds, fixed_postion,
             exp_kx_r = np.exp(2*np.pi*1j*FFFboxs.reshape(-1,3)@ft_kvec).reshape(FFFboxs.shape[:3])
             ft_wfcr *= exp_kx_r[None,None,None,...]
             #
+            Akcv = Akcv.astype(np.complex64)
+            fx_wfc = fx_wfc.astype(np.complex64)
+            ft_wfcr = ft_wfcr.astype(np.complex64)
+            exe_tmp_wf = exe_tmp_wf.astype(np.complex64)
             if fix_particle == 'h':
                 np.einsum('ncv,vy,cxijk->nxyijk',Akcv[:,ik,...],fx_wfc[0],ft_wfcr[0],
                           optimize=True,out=exe_tmp_wf[:,:,:,ik-ikstart])


### PR DESCRIPTION
…instead of 64.

While testing the function to real_wf_to_cube(), I faced the dtype mismatch error twice.
Once finding the nearest fft grid point `fixed_postion = np.round(fixed_postion * fft_box) / fft_box`
Once in the einsum `                np.einsum('ncv,vy,cxijk->nxyijk',Akcv[:,ik,...],fx_wfc[0],ft_wfcr[0],
                          optimize=True,out=exe_tmp_wf[:,:,:,ik-ikstart])`

I solved these errors by converting the arrays `.astype(np.complex(64)`, but this is not the most elegant solution ofcourse.

@muralidhar-nalabothula Thank you for the implementation, it's great.